### PR TITLE
Added missing ID (braking current pylexibank)

### DIFF
--- a/lexibank_tryonsolomon.py
+++ b/lexibank_tryonsolomon.py
@@ -30,6 +30,7 @@ SELECT language, gloss, lexeme FROM lexemes ORDER BY language, gloss, lexeme
 
 class Dataset(BaseDataset):
     dir = Path(__file__).parent
+    id = 'tryonsolomon'
 
     def cmd_download(self, **kw):
         pass


### PR DESCRIPTION
The current master is not compiling (and is making lexibank, as installed via PyPI, throw a `ValueError`, see traceback below) due to a missing `id` field, which is mandatory with the current `pylexibank.dataset.Dataset` (and necessary if lexibank is run in a different directory).

This commit solves this problem. Please note that I am *not* pushing the CLDF files which are however missing (the ones in the repository don't have the segmented values, reported in the `README`).

```
(env) tresoldi@shh.mpg.de@dlt5802808l:~/my_lexibank$ lexibank
Traceback (most recent call last):
  File "/home/tresoldi/my_lexibank/env/bin/lexibank", line 9, in <module>
    load_entry_point('pylexibank==0.13.1.dev0', 'console_scripts', 'lexibank')()
  File "/home/tresoldi/my_lexibank/env/lib/python3.5/site-packages/pylexibank/__main__.py", line 116, in main
    cfg, datasets = configure()
  File "/home/tresoldi/my_lexibank/env/lib/python3.5/site-packages/pylexibank/__main__.py", line 106, in configure
    key=lambda d: d.id)
  File "/home/tresoldi/my_lexibank/env/lib/python3.5/site-packages/pylexibank/dataset.py", line 662, in iter_datasets
    yield ep.load()(glottolog=glottolog, concepticon=concepticon)
  File "/home/tresoldi/my_lexibank/env/lib/python3.5/site-packages/pylexibank/dataset.py", line 201, in __init__
    raise ValueError
ValueError
```